### PR TITLE
Remove .php extensions for clean URL's

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,16 +1,26 @@
 <IfModule mod_rewrite.c>
 RewriteEngine On
 RewriteBase /
+
 # Redirect to HTTPS
 RewriteCond %{http:X-FORWARDED-PROTO} !https
 RewriteCond %{HTTP_HOST} ^nejsconf\.com$ [NC]
 RewriteRule ^(.*)$ https://%{HTTP_HOST}/$1 [R,L]
 # End
+
 RewriteCond %{HTTP:Accept-Encoding} gzip
 RewriteCond %{REQUEST_FILENAME}.zgz -f 
 RewriteRule ^(.*)$ $1.zgz [L]
+
 RedirectMatch 301 ^/cfp$ https://docs.google.com/forms/d/1vqaODm8zG0_R8oXi1xVvWG4VrKEP5IicKYfjOLfntIk/viewform
 RedirectMatch 301 ^/cfp/$ https://docs.google.com/forms/d/1vqaODm8zG0_R8oXi1xVvWG4VrKEP5IicKYfjOLfntIk/viewform
+
+# Clean off .php extensions
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule ^(.*) $1.php [L]
+
+RewriteRule ^(.*).php /$1 [R=301,L]
 </IfModule>
 
 # mod_deflate isn't included on the production host, so we have a workaround


### PR DESCRIPTION
Language is an implementation detail, drop the .php for clean URL's.

```
https://nejsconf.com/example.php => 301 => https://nejsconf.com/example
```
