### PR TITLE
Fix redirect loop.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -20,7 +20,8 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*) $1.php [L]
 
-RewriteRule ^(.*).php /$1 [R=301,L]
+RewriteCond %{ENV:REDIRECT_STATUS} ^$
+RewriteRule ^(.+)\.php $1 [R=301,L]
 </IfModule>
 
 # mod_deflate isn't included on the production host, so we have a workaround


### PR DESCRIPTION
Fixes redirect loop referenced in #15.

``` shell
jmhobbs@venera:~ ✪ curl -v https://nejsconf.com/test.php
* Hostname was NOT found in DNS cache
*   Trying 208.94.116.4...
* Connected to nejsconf.com (208.94.116.4) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: nejsconf.com
* Server certificate: COMODO RSA Domain Validation Secure Server CA
* Server certificate: COMODO RSA Certification Authority
* Server certificate: AddTrust External CA Root
> GET /test.php HTTP/1.1
> User-Agent: curl/7.37.1
> Host: nejsconf.com
> Accept: */*
> 
< HTTP/1.1 301 Moved Permanently
< Date: Wed, 20 May 2015 21:28:22 GMT
* Server Apache is not blacklisted
< Server: Apache
< Location: http://nejsconf.com/test
< Cache-Control: max-age=0
< Expires: Wed, 20 May 2015 21:28:22 GMT
< Content-Length: 232
< Content-Type: text/html; charset=iso-8859-1
< Via: 1.1 vhost.phx3.nearlyfreespeech.net (squid)
< 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="http://nejsconf.com/test">here</a>.</p>
</body></html>
* Connection #0 to host nejsconf.com left intact
jmhobbs@venera:~ ✪ curl -v https://nejsconf.com/test
* Hostname was NOT found in DNS cache
*   Trying 208.94.116.4...
* Connected to nejsconf.com (208.94.116.4) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
* Server certificate: nejsconf.com
* Server certificate: COMODO RSA Domain Validation Secure Server CA
* Server certificate: COMODO RSA Certification Authority
* Server certificate: AddTrust External CA Root
> GET /test HTTP/1.1
> User-Agent: curl/7.37.1
> Host: nejsconf.com
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Wed, 20 May 2015 21:28:26 GMT
* Server Apache is not blacklisted
< Server: Apache
< Cache-Control: max-age=2592000, public
< Expires: Fri, 19 Jun 2015 21:28:26 GMT
< Strict-Transport-Security: max-age=31536000
< Content-Type: text/plain; charset=utf-8
< Via: 1.1 vhost.phx3.nearlyfreespeech.net (squid)
< Transfer-Encoding: chunked
< 
* Connection #0 to host nejsconf.com left intact
Hello Issue #15
```
